### PR TITLE
Changes to Use CORS for Cross Domain Ajax Requests and add a route that responds to GET

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Your `default.json` should contain:
 ```
 {
   "Mailgun": {
-    "apiKey":  "YOUR_API_KEY",
-    "domain":   "http://yourdomain.com",
+    "apiKey": "YOUR_PRIVATE_API_KEY",
+    "domain": "yourdomain.com",
     "sender": "your-email@gmail.com"
   }
 }
@@ -88,3 +88,26 @@ Response:
 You should be all set up now. All you need to do is copy this application and start it wherever you want a local server.
 
 Let me know if you've got any feedback about it or feature requests!
+
+##letsencrypt
+
+To use with letsencrypt, run the following command from the directory where letsencrypt is installed:
+
+    ./letsencrypt-auto certonly --webroot -w /var/www/mailgunner/ -d mailgun.example.com
+
+Once the certificate has been generated, uncomment the relevant lines in the nginx conf for the mailgun server.
+
+Don't forget to add a CNAME record for your domain.
+
+To auto renew the letsencrypt certificate (they expire every three months), add the following command to your crontab:
+
+    ./letsencrypt-auto certonly --renew --webroot -w /var/www/mailgunner/ -d mailgun.example.com
+
+If the certificat fails to generate, you may need to manually create the `.well-known` folder in the mailgunner root directory:
+
+    mkdir .well-known
+
+and then add the `acme-challenge` directory:
+
+  cd .well-known
+  mkdir acme-challenge

--- a/README.md
+++ b/README.md
@@ -109,5 +109,5 @@ If the certificat fails to generate, you may need to manually create the `.well-
 
 and then add the `acme-challenge` directory:
 
-  cd .well-known
-  mkdir acme-challenge
+    cd .well-known
+    mkdir acme-challenge

--- a/app.js
+++ b/app.js
@@ -1,12 +1,19 @@
 var express = require('express'),
     bodyParser = require('body-parser'),
+    cors = require('cors'),
     mailgunner = require('./routes/mailgunner');
 
 var app = express();
 
 //configure body-parser
+app.use(cors());
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
+
+app.get('/', function(req, res) {
+  res.send("Please send a post request");
+});
+
 app.use('/api', mailgunner); //This is our route middleware
 
 module.exports = app;

--- a/example_nginx_conf_mailgun.example.com
+++ b/example_nginx_conf_mailgun.example.com
@@ -1,0 +1,52 @@
+server {
+
+  listen 80;
+  server_name mailgun.example.com;
+
+  access_log /var/log/nginx/mailgun.example.com.log;
+
+  location /.well-known {
+    root /var/www/mailgunner;
+  }
+
+  location / {
+    proxy_pass http://127.0.0.1:3030;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_set_header Host $host;
+    proxy_cache_bypass $http_upgrade;
+  }
+
+  # return 301 https://$server_name$request_uri;
+}
+
+
+# server {
+
+#  listen 443 ssl;
+#  server_name mailgun.example.com;
+
+#  access_log /var/log/nginx/mailgun.example.com.log;
+
+#  location / {
+#    proxy_pass http://127.0.0.1:3030;
+#    proxy_http_version 1.1;
+#    proxy_set_header Upgrade $http_upgrade;
+#    proxy_set_header Connection 'upgrade';
+#    proxy_set_header Host $host;
+#    proxy_cache_bypass $http_upgrade;
+#  }
+
+#  ssl on;
+
+#  ssl_certificate /etc/letsencrypt/live/mailgun.example.com/cert.pem;
+#  ssl_certificate_key /etc/letsencrypt/live/mailgun.example.com/privkey.pem;
+
+#  ssl_stapling on;
+#  ssl_stapling_verify on;
+#  ssl_trusted_certificate /etc/letsencrypt/live/mailgun.example.com/fullchain.pem;
+
+#  ssl_session_timeout 5m;
+
+#}

--- a/routes/mailgunner.js
+++ b/routes/mailgunner.js
@@ -8,6 +8,11 @@ var router = express.Router(),
     domain  = config.get('Mailgun.domain'),
     sender  = config.get('Mailgun.sender');
 
+router.route('/').get(function(req,res) {
+  res.send("Please send a post request");
+});
+
+
 router.route('/submit/:mail').post(function(req,res) {
     var mailgun = new Mailgun({apiKey: api_key, domain: domain});
     var name = req.body.name,


### PR DESCRIPTION
Hi James,

I was setting up a Ghost blog for myself and got to the point of adding a contact form and the only non-embedded blog post I found was yours.

I was stumbling for a bit before eventually figuring out my own setup where no additional ports needed to be opened up and also allowed it to be used with an SSL certificate (if Ghost blog is https then an ajax request to a non-https domain will fail).

I've tried to be as descriptive as possible to try and help others who might run into the same issues as I did but if this is something you'd like to add to your repo then please feel free, additionally, if there's any changes you'd like me to make then just let me know.

The only thing I'm unsure of is the fact I've added the GET route twice, I forgot to test taking one out as it would be nicer if it wasn't duplicated.

Thanks,
Martin

<!---
@huboard:{"order":1.0,"milestone_order":1,"custom_state":""}
-->
